### PR TITLE
Enabled ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2211,6 +2211,12 @@ if(WOLFSSL_EXAMPLES)
     set_property(TARGET unit_test
                  PROPERTY RUNTIME_OUTPUT_NAME
                  unit.test)
+    enable_testing()
+    add_test(
+        NAME unit.test
+        COMMAND $<TARGET_FILE:unit_test>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 endif()
 
 if(WOLFSSL_CRYPT_TESTS)


### PR DESCRIPTION
# Description

This enables ctest and uses existing unit.test executable.  This automates test execution for wolfssl in external projects and allows using `make test`  or `ninja test` to run the tests in the correct directory

# Testing

How did you test?

mkdir build
cd build
cmake -G Ninja ..
ninja
ninja test

the above commands successfully build and run the unit.test executable and reports errors.


# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
